### PR TITLE
Reduced compiler warnings

### DIFF
--- a/bootstrap/src/core/assert.h
+++ b/bootstrap/src/core/assert.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 
 #ifdef FRX_ENABLE_ASSERTS
-#define FRX_ASSERT(condition) if(!(condition)) { fprintf(stderr, "Assertion failed at %s:%zu: \"%s\"\n", __FILE__, __LINE__, #condition); exit(EXIT_FAILURE); }
+#define FRX_ASSERT(condition) if(!(condition)) { fprintf(stderr, "Assertion failed at %s:%d: \"%s\"\n", __FILE__, __LINE__, #condition); exit(EXIT_FAILURE); }
 #else
 #define FRX_ASSERT(condition)
 #endif


### PR DESCRIPTION
Changed specifier from %zu to %d for __LINE__ to remove warnings.