### PR TITLE
Arena bugfix: Added important assert

### DIFF
--- a/bootstrap/src/core/arena.c
+++ b/bootstrap/src/core/arena.c
@@ -23,6 +23,8 @@ void* arena_alloc(Arena* arena, usize size)
 
     FRX_ASSERT(arena->buffer != NULL);
 
+    FRX_ASSERT(arena->pos + size <= arena->size);
+
     void* block = arena->buffer + arena->pos;
 
     arena->pos += size;


### PR DESCRIPTION
We now assert that the whole allocated block is inside the arena's buffer.