### PR TITLE
Fixed a bug regarding enum constants

### DIFF
--- a/bootstrap/input.txt
+++ b/bootstrap/input.txt
@@ -72,7 +72,7 @@ enum Day : u8
     MONDAY,
     TUESDAY,
     WEDNESDAY,
-    THURSDAY,
+    THURSDAY = 99,
     FRIDAY,
     SATURDAY,
     SUNDAY

--- a/bootstrap/src/ast.h
+++ b/bootstrap/src/ast.h
@@ -370,6 +370,8 @@ void ast_print_function_call(const ASTFunctionCall* function_call, usize depth);
 
 void ast_print_scope(const ASTScope* scope, usize depth);
 
+void ast_print_enum_definition(const ASTEnumDefinition* enum_definition, usize depth);
+
 void ast_print_struct_definition(const ASTStructDefinition* struct_definition, usize depth);
 
 void ast_print_namespace(const ASTNamespace* namespace, usize depth);


### PR DESCRIPTION
Only enum constants that consisted of a pure identifier could be parsed. Now constants that are assigned a specific value via the equals operator will be parsed correctly as well.